### PR TITLE
Add ID Tags to FileList

### DIFF
--- a/src/lib/components/gameModal/view/ColoredRomList.svelte
+++ b/src/lib/components/gameModal/view/ColoredRomList.svelte
@@ -4,6 +4,7 @@
 	import type { AltColorFile, FileUpload } from '$lib/types/VPin';
 	import type { Mode } from 'fs';
 	import UrlChips from '../../URLChips.svelte';
+	import IdTag from '../../IdTag.svelte';
 	import { clipboard, getToastStore } from '@skeletonlabs/skeleton';
 
 	export let title: string = '';
@@ -35,6 +36,7 @@
 						<th>Folder</th>
 						<th>Comment</th>
 						<th>URLs</th>
+						<th>ID</th>
 						<th>Updated at</th>
 					</tr>
 				</thead>
@@ -65,6 +67,7 @@
 							>
 							<td>{file.comment || ''}</td>
 							<td class="w-40"><UrlChips urls={file.urls} /></td>
+							<td class="w-20"><IdTag id={file.id} /></td>
 							<td class="w-32">{formatDate(file.updatedAt)}</td>
 						</tr>
 					{/each}

--- a/src/lib/components/gameModal/view/FileList.svelte
+++ b/src/lib/components/gameModal/view/FileList.svelte
@@ -4,6 +4,7 @@
 	import type { FileUpload } from '$lib/types/VPin';
 	import type { Mode } from 'fs';
 	import UrlChips from '../../URLChips.svelte';
+	import IdTag from '../../IdTag.svelte';
 
 	export let title: string = '';
 	export let fileType: Mode;
@@ -31,6 +32,7 @@
 						<th>Authors</th>
 						<th>Comment</th>
 						<th>URLs</th>
+						<th>ID</th>
 						<th>Updated at</th>
 					</tr>
 				</thead>
@@ -46,6 +48,7 @@
 							<td class="w-56">{file.authors?.join(', ') || ''}</td>
 							<td>{file.comment || ''}</td>
 							<td class="w-40"><UrlChips urls={file.urls} /></td>
+							<td class="w-20"><IdTag id={file.id} /></td>
 							<td class="w-32">{formatDate(file.updatedAt)}</td>
 						</tr>
 					{/each}


### PR DESCRIPTION
Files currently do not have ID tags presented in the UI. I'm building an app and trying to link to specific files in the vpsdb and having these chips makes getting the IDs so much easier!