### PR TITLE
fix display of table detail cards on safari -- could not see hover effect

### DIFF
--- a/src/lib/components/cards/TableDetailCard.svelte
+++ b/src/lib/components/cards/TableDetailCard.svelte
@@ -13,7 +13,7 @@
 	export let gameId: string;
 </script>
 
-<div class="wrapper relative z-0" id={file.id} data-gameid={gameId} data-filetype="tableFiles">
+<div class="flex flex-col" id={file.id} data-gameid={gameId} data-filetype="tableFiles">
 	<a {href} target={href ? '_blank' : ''} class="relative group">
 		<div
 			style="background:{$modeCurrent ? 'rgba(255,255,255,.4)' : 'rgba(0,0,0,.4)'}!important;"


### PR DESCRIPTION
- size of the element was 0x0, perhaps because of the position absolute
- copy the classes from the b2s detail card, which does work