### PR TITLE
improved search

### DIFF
--- a/src/lib/components/popups/SortPopup.svelte
+++ b/src/lib/components/popups/SortPopup.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { Search } from '$lib/stores/SearchStore';
-	const { sortBy } = Search;
+	const { sortBy, isSearchActive } = Search;
 
 	import { sortOptions } from '$lib/types/Filter';
 </script>
@@ -14,10 +14,14 @@
 <div class="card 8 shadow-xl popup" data-popup="popupSort">
 	<div class="p-4">
 		{#each sortOptions as sort}
-			<label class="flex items-center space-x-2">
-				<input class="hidden" type="radio" name="sortBy" value={sort.sortBy} bind:group={$sortBy} />
-				<p class:sort-active={$sortBy == sort.sortBy}>{sort.name}</p>
-			</label>
+			{#if sort.sortBy == 'search' && !$isSearchActive}
+				<!-- no option for search sort -->
+			{:else}
+				<label class="flex items-center space-x-2">
+					<input class="hidden" type="radio" name="sortBy" value={sort.sortBy} bind:group={$sortBy} />
+					<p class:sort-active={$sortBy == sort.sortBy}>{sort.name}</p>
+				</label>
+			{/if}
 		{/each}
 	</div>
 </div>

--- a/src/lib/types/Filter.ts
+++ b/src/lib/types/Filter.ts
@@ -74,6 +74,7 @@ export type LetterFilter = (typeof letters)[number];
 export type Mode = 'game' | (typeof fileTypes)[number];
 
 export type SortBy =
+	| 'search'
 	| 'lastUpdated'
 	| 'leastUpdated'
 	| 'yearASC'
@@ -110,6 +111,11 @@ export const sortOptions: {
 	compareGames: (a: Game, b: Game) => number;
 	compareFiles: (af: FileUpload, ag: Game, bf: FileUpload, bg: Game) => number;
 }[] = [
+		{
+			name: "Search Relevance", sortBy: 'search',
+			compareGames: (a, b) => { return sortUpdatedGames(a, b) },
+			compareFiles: (af, ag, bf, bg) => { return sortUpdatedFiles(af, bf) }
+		},
 		{
 			name: "Last Updated", sortBy: 'lastUpdated',
 			compareGames: (a, b) => { return sortUpdatedGames(a, b) },


### PR DESCRIPTION
**Search index uses concatenated game.name as an auxiliary**

- search "dragon ball” in Games
	- would like to match "dragonball"
- search “dragonball” in Games
	- would like to match "dragon ball”

- search “countdown” in Games
	- would like to match “count-down”
- search "count-down” or “count down” in Games
	- would like to match “count-down” (currently works and should stay working)

**Search index includes _edition_ from tables**

- search “boat” in Games
	- would like to match Jaws (bigger boat edition)
	- various other hits because of the fuzzy match, but _boat_ direct hits at top
- search “boat” in Tables
	- would like to match Jaws (bigger boat edition)

**Search ignores author fields from unrelated files (Games includes tableFiles)**

- search “dragon” in Games
	- expect games with Dragon in the name
	- expect tables authored by Dragon44
	- do not expect The Simpsons Treehouse of Horror (b2s hit on Dragon44)

**Fix case sensitivity in file / author hits**

- search “dragon” in B2S
	- expect The Simpsons Treehouse of Horror (Dragon44)

**Search + sort — search returns results in search relevance order**

- search for “dragon” in Games
	- should see something with Dragon in the title, e.g. Dragon or Dragon’s Lair

- search for “dragon” in Games and set sort order to Last Updated
	- should see Dragonball first