### PR TITLE
show only "createdAt" (with the label updatedAt)

### DIFF
--- a/src/lib/components/cards/GameCard.svelte
+++ b/src/lib/components/cards/GameCard.svelte
@@ -91,7 +91,7 @@
 			<div class="flex mt-auto w-full">
 				<div class="flex flex-col items-center justify-center flex-1 gap-1">
 					<p class="text-xs font-bold uppercase opacity-40">Updated at</p>
-					<p class="">{formatDate(file.updatedAt)}</p>
+					<p class="">{formatDate(file.lastCreatedAt ?? file.updatedAt)}</p>
 				</div>
 				<div class="bg-surface-900-50-token h-full w-px opacity-20" />
 				<div class="flex flex-col items-center justify-center flex-1 gap-1">

--- a/src/lib/components/cards/GameCardHover.svelte
+++ b/src/lib/components/cards/GameCardHover.svelte
@@ -99,7 +99,7 @@
 			<div class="flex mt-auto w-full">
 				<div class="flex flex-col items-center justify-center flex-1 gap-1">
 					<p class="text-xs font-bold uppercase opacity-40">Updated at</p>
-					<p class="">{formatDate(game.updatedAt)}</p>
+					<p class="">{formatDate(game.lastCreatedAt ?? game.updatedAt)}</p>
 				</div>
 				<div class="bg-surface-900-50-token h-full w-px opacity-20" />
 				<div class="flex flex-col items-center justify-center flex-1 gap-1">

--- a/src/lib/components/cards/TableCard.svelte
+++ b/src/lib/components/cards/TableCard.svelte
@@ -95,12 +95,7 @@
 			<div class="flex mt-auto w-full">
 				<div class="flex flex-col items-center justify-center flex-1 gap-1">
 					<p class="text-xs font-bold uppercase opacity-40">Updated at</p>
-					<p class="">{formatDate(file.updatedAt)}</p>
-				</div>
-				<div class="bg-surface-900-50-token h-full w-px opacity-20" />
-				<div class="flex flex-col items-center justify-center flex-1 gap-1">
-					<p class="text-xs font-bold uppercase opacity-40">Added at</p>
-					<p class="">{formatDate(file.createdAt || file.updatedAt)}</p>
+					<p class="">{formatDate(file.createdAt ?? file.updatedAt)}</p>
 				</div>
 			</div>
 		</div>

--- a/src/lib/components/cards/TableCardHover.svelte
+++ b/src/lib/components/cards/TableCardHover.svelte
@@ -120,12 +120,7 @@
 			<div class="flex mt-auto w-full">
 				<div class="flex flex-col items-center justify-center flex-1 gap-1">
 					<p class="text-xs font-bold uppercase opacity-40">Updated at</p>
-					<p class="">{formatDate(table.updatedAt)}</p>
-				</div>
-				<div class="bg-surface-900-50-token h-full w-px opacity-20" />
-				<div class="flex flex-col items-center justify-center flex-1 gap-1">
-					<p class="text-xs font-bold uppercase opacity-40">Added at</p>
-					<p class="">{formatDate(table.createdAt || table.updatedAt)}</p>
+					<p class="">{formatDate(table.createdAt ?? table.updatedAt)}</p>
 				</div>
 			</div>
 		</div>

--- a/src/lib/components/cards/TableDetailCard.svelte
+++ b/src/lib/components/cards/TableDetailCard.svelte
@@ -30,12 +30,7 @@
 			<div class="flex mt-auto w-full">
 				<div class="flex flex-col items-center justify-center flex-1 gap-1">
 					<p class="text-xs font-bold uppercase opacity-40">Updated at</p>
-					<p class="">{formatDate(file.updatedAt)}</p>
-				</div>
-				<div class="bg-surface-900-50-token h-full w-px opacity-20" />
-				<div class="flex flex-col items-center justify-center flex-1 gap-1">
-					<p class="text-xs font-bold uppercase opacity-40">Added at</p>
-					<p class="">{formatDate(file.createdAt || file.updatedAt)}</p>
+					<p class="">{formatDate(file.createdAt ?? file.updatedAt)}</p>
 				</div>
 			</div>
 		</div>

--- a/src/lib/components/gameModal/view/ColoredRomList.svelte
+++ b/src/lib/components/gameModal/view/ColoredRomList.svelte
@@ -68,7 +68,7 @@
 							<td>{file.comment || ''}</td>
 							<td class="w-40"><UrlChips urls={file.urls} /></td>
 							<td class="w-20"><IdTag id={file.id} /></td>
-							<td class="w-32">{formatDate(file.updatedAt)}</td>
+							<td class="w-32">{formatDate(file.createdAt ?? file.updatedAt)}</td>
 						</tr>
 					{/each}
 				</tbody>

--- a/src/lib/components/gameModal/view/FileList.svelte
+++ b/src/lib/components/gameModal/view/FileList.svelte
@@ -49,7 +49,7 @@
 							<td>{file.comment || ''}</td>
 							<td class="w-40"><UrlChips urls={file.urls} /></td>
 							<td class="w-20"><IdTag id={file.id} /></td>
-							<td class="w-32">{formatDate(file.updatedAt)}</td>
+							<td class="w-32">{formatDate(file.createdAt ?? file.updatedAt)}</td>
 						</tr>
 					{/each}
 				</tbody>

--- a/src/lib/components/gameModal/view/Header.svelte
+++ b/src/lib/components/gameModal/view/Header.svelte
@@ -73,7 +73,7 @@
 			<div class="bg-surface-900-50-token h-full w-px opacity-10" />
 			<div class="flex flex-col items-center justify-center flex-1 gap-1">
 				<p class="text-xs font-bold uppercase opacity-40">Updated at</p>
-				<p class="">{formatDate(game.updatedAt)}</p>
+				<p class="">{formatDate(game.lastCreatedAt ?? game.updatedAt)}</p>
 			</div>
 			<div class="bg-surface-900-50-token h-full w-px opacity-10" />
 			<div class="flex flex-col items-center justify-center flex-1 gap-1">


### PR DESCRIPTION
- the updatedAt field in the database is just the last time the object (game or file) was touched
- the createdAt field matches (assuming edits are done correctly) the date on the object e.g. in VPU
- there has been confusion because
	- both are shown
	- the sort order is called "last updated" but is really createdAt
	- to users the "createdAt" sounds like when the entry was first made